### PR TITLE
Expose webdriver wait functionality

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,10 +4,6 @@ The following are features I would like to implement or limitations I would like
 
 ## Features ##
 
-### Wait Functionality ###
-
-WebDriver provides explicit and implicit waits.
-
 ### Grid Support ###
 
 Selenium Grid is now part of the standalone jar distribution of Selenium server. It would be nice to provide mechanisms to easily start the grid and child nodes directly from code.

--- a/src/clj_webdriver/core.clj
+++ b/src/clj_webdriver/core.clj
@@ -22,9 +22,10 @@
            [org.openqa.selenium.ie InternetExplorerDriver]
            [org.openqa.selenium.chrome ChromeDriver]
            [org.openqa.selenium.htmlunit HtmlUnitDriver]
-           [org.openqa.selenium.support.ui Select]
+           [org.openqa.selenium.support.ui Select WebDriverWait ExpectedCondition]
            [java.util Date]
-           [java.io File]))
+           [java.io File]
+           [java.util.concurrent TimeUnit]))
 
 (def webdriver-drivers
   {:firefox FirefoxDriver
@@ -394,3 +395,11 @@
      (first (find-them driver attr-val)))
   ([driver tag attr-val]
      (first (find-them driver tag attr-val))))
+
+(defn implicit-wait [driver timeout]
+  (.implicitlyWait (.. driver manage timeouts) timeout TimeUnit/SECONDS))
+
+(defn wait-until [driver pred & {:keys [timeout] :or {timeout 5}}]
+  (let [wait (WebDriverWait. driver timeout)]
+    (.until wait (proxy [ExpectedCondition] []
+                   (apply [d] (pred d))))))

--- a/test/clj_webdriver/test/core.clj
+++ b/test/clj_webdriver/test/core.clj
@@ -2,7 +2,8 @@
   (:require [clj-webdriver.test.example-app.core :as web-app])
   (:use [clj-webdriver.core] :reload)
   (:use ring.adapter.jetty)
-  (:use [clojure.test]))
+  (:use [clojure.test])
+  (:import [org.openqa.selenium TimeoutException]))
 
 ;; Setup
 (def test-port 5744)
@@ -222,6 +223,33 @@
   (close b)
   (is (= test-base-url
          (:url (window-handle b)))))
+
+(deftest wait-until-should-wait-for-condition
+  (is (= "Ministache" (title b)))
+  (doto b
+    (execute-script "setTimeout(function () { window.document.title = \"asdf\"}, 3000)")
+    (wait-until (fn [d] (= "asdf" (title d)))))
+  (is (= "asdf" (title b))))
+
+(deftest wait-until-should-throw-on-timeout
+  (is (thrown? TimeoutException
+               (doto b
+                 (execute-script "setTimeout(function () { window.document.title = \"test\"}, 6000)")
+                 (wait-until (fn [d] (= "test" (title d))))))))
+
+(deftest wait-until-should-allow-timeout-argument
+  (is (thrown? TimeoutException
+               (doto b
+                 (execute-script "setTimeout(function () { window.document.title = \"test\"}, 10000)")
+                 (wait-until (fn [d] (= "test" (title d))) :timeout 1)))))
+
+(deftest implicit-wait-should-cause-find-to-wait
+  (doto b
+    (implicit-wait 3)
+    (execute-script "setTimeout(function () { window.document.body.innerHTML = \"<div id='test'>hi!</div>\"}, 1000)"))
+  (is (= "test"
+         (attribute (find-element b (by-id "test")) :id))))
+
 ;; TODO:
 ;;   * Form element tests (comprehensive)
 ;;   * Exception throwing (esp. for find-it/find-them argument handling)p


### PR DESCRIPTION
Create wait-until and implicitly-wait functions for the driver.

Not all functionality is exposed.  I imagine testing something like sleep in miliseconds would be ugly, though perhaps a mock would work since its calling a java object.
