### PR TITLE
Modification of exists? to return truthy value rather than a boolean.

### DIFF
--- a/src/clj_webdriver/core.clj
+++ b/src/clj_webdriver/core.clj
@@ -218,11 +218,12 @@
   (.isEnabled element))
 
 (defmacro exists?
+  "Returns element matching the find-it-form if it exists, or nil if it does not"
   [find-it-form]
-  `(try ~find-it-form
-        true
-        (catch org.openqa.selenium.NoSuchElementException e#
-          false)))
+  `(try 
+      ~find-it-form
+      (catch org.openqa.selenium.NoSuchElementException e#
+        nil)))
 
 (defn visible?
   "Returns true if the given element object is visible/displayed"

--- a/test/clj_webdriver/test/core.clj
+++ b/test/clj_webdriver/test/core.clj
@@ -133,14 +133,17 @@
          (attribute (find-it b :input {:type "text", :name #"last_"}) "value")))
   (is (= "Smith"
          (attribute (find-it b [:div {:id "content"}, :input {:name #"last_"}]) "value")))
-  (is (true?
-       (-> b
-           (find-it :a)
-           exists?)))
-  (is (false?
+  (is (-> b
+        (find-it :a)
+        exists?))
+  (is (not
        (-> b
            (find-it :area)
            exists?)))
+  (is (nil?
+       (-> b
+           (find-it :area)
+           exists?)))           
   (is (thrown? org.openqa.selenium.NoSuchElementException
                (find-it b :area))))
 


### PR DESCRIPTION
Hi,

I've made a small change to the exists? function, modifying it (and the associated tests) to return the component or nil rather than true/false - making use of clojure's notion of truthyness. 

I've found it useful in testing, where I can assign the result to a temporary variable, asserting that it returned a component, and if that is successful diving into more detailed analysis of the component without having to re-query for it.

Hopefully you find this useful.

Thanks for all your hard work on the project - I've loved using it.

Rob.
