### PR TITLE
Extracted css-value

### DIFF
--- a/src/clj_webdriver/core.clj
+++ b/src/clj_webdriver/core.clj
@@ -84,6 +84,7 @@
   "Basic actions on elements"
   (attribute [element attr] "Retrieve the value of the attribute of the given element object")
   (click [element] "Click a particular HTML element")
+	(css-value [element property] "Return the value of the given CSS property")
   (displayed? [element] "Returns true if the given element object is visible/displayed")
   (drag-and-drop-by [element x y] "Drag an element by `x` pixels to the right and `y` pixels down. Use negative numbers for opposite directions.")
   (drag-and-drop-on [element-a element-b] "Drag `element-a` onto `element-b`. The (0,0) coordinates (top-left corners) of each element are aligned.")

--- a/src/clj_webdriver/core_element.clj
+++ b/src/clj_webdriver/core_element.clj
@@ -33,6 +33,9 @@
     (cache/set-status :check)
     nil)
 
+	(css-value [element property]
+		(.getCssValue (:webelement element) property))
+
   (displayed? [element]
     (.isDisplayed (:webelement element)))
 
@@ -48,8 +51,8 @@
     (not (nil? (:webelement element))))
 
   (flash [element]
-    (let [original-color (if (.getCssValue (:webelement element) "background-color")
-                           (.getCssValue (:webelement element) "background-color")
+    (let [original-color (if (css-value element "background-color")
+                           (css-value element "background-color")
                            "transparent")
           orig-colors (repeat original-color)
           change-colors (interleave (repeat "red") (repeat "blue"))]


### PR DESCRIPTION
Pulled .getCssValue into its own function in the IElement protocol
Refactored hover to use css-value instead of .getCssValue

There is no test written for this because I was unable to run `lein test` successfully. It appears that the server did not startup. Also, though easy to fix, chromedriver needs manual downloading and setup to make tests work. Would love to help find a way to avoid that as it would lower the bar of entry to working with clj-webdriver. 

In my testing code, I've been doing something like this...

``` clojure
(defn chromedriver
  "Return the name of the chrome driver to be used. This is based on the os name."
  []
  (str "driver/chromedriver_" (->> (System/getProperty "os.name")
                                   (re-find #"[^ ]*")
                                   (str/lower-case))))

(defn start-browser
  "Return a Webdriver. Defaults to Chrome browser."
  ([url] (start-browser url :chrome))
  ([url browser]
     (if (= :chrome browser)
       (System/setProperty "webdriver.chrome.driver" (chromedriver)))
     (start {:browser browser} url)))
```

Mind you, that's hard coding chromedriver and it also means including it in the source repo since it's not available on clojars or the maven repo. Agree that that's less than ideal, but I do like that starting the browser automatically configures itself.
