### PR TITLE
taxi/back taxi/forward and core/focus now return obj

### DIFF
--- a/src/clj_webdriver/core_element.clj
+++ b/src/clj_webdriver/core_element.clj
@@ -59,7 +59,8 @@
 
   (focus [element]
     (execute-script*
-     (.getWrappedDriver (:webelement element)) "return arguments[0].focus()" (:webelement element)))
+     (.getWrappedDriver (:webelement element)) "return arguments[0].focus()" (:webelement element))
+    element)
 
   (html [element]
     (browserbot (.getWrappedDriver (:webelement element)) "getOuterHTML" (:webelement element)))

--- a/src/clj_webdriver/taxi.clj
+++ b/src/clj_webdriver/taxi.clj
@@ -277,7 +277,8 @@
   ([n] (back *driver* n))
   ([driver n]
      (dotimes [m n]
-       (core/back driver))))
+       (core/back driver))
+     driver))
 
 (defn close
   "Close the browser. If multiple windows are open, this only closes the active window.
@@ -319,7 +320,8 @@
   ([n] (forward *driver* n))
   ([driver n]
      (dotimes [m n]
-       (core/forward *driver*))))
+       (core/forward *driver*))
+     driver))
 
 (defn get-url
   "Navigate the browser to `url`.


### PR DESCRIPTION
The following functions now properly return obj.

`clj-webdriver.taxi/back`
`clj-webdriver.taxi/forward`
`clj-webdriver.core/focus`
