### PR TITLE
Removed the laziness from quick-fill

### DIFF
--- a/src/clj_webdriver/taxi.clj
+++ b/src/clj_webdriver/taxi.clj
@@ -24,10 +24,10 @@
   (let [new-driver (if (driver? browser-spec)
                      browser-spec
                      (core/new-driver browser-spec))]
-       (alter-var-root (var *driver*)
-                       (constantly new-driver)
-                       (when (thread-bound? (var *driver*))
-                         (set! *driver* new-driver)))))
+    (alter-var-root (var *driver*)
+                    (constantly new-driver)
+                    (when (thread-bound? (var *driver*))
+                      (set! *driver* new-driver)))))
 
 (declare to)
 (defn set-driver!
@@ -130,10 +130,10 @@
        submit))"
   [browser-spec & body]
   `(binding [*driver* (core/new-driver ~browser-spec)]
-    (try
-      ~@body
-      (finally
-        (quit)))))
+     (try
+       ~@body
+       (finally
+         (quit)))))
 
 (defmacro with-driver-fn
   "Given a `browser-spec` to start a browser and a `finder-fn` to use as a finding function, execute the forms in `body`, then call `quit` on the browser.
@@ -155,10 +155,10 @@
   [browser-spec finder-fn & body]
   `(binding [*driver* (core/new-driver ~browser-spec)
              *finder-fn* ~finder-fn]
-    (try
-      ~@body
-      (finally
-        (quit)))))
+     (try
+       ~@body
+       (finally
+         (quit)))))
 
 (defn css-finder
   "Given a CSS query `q`, return a lazy seq of the elements found by calling `find-elements` with `by-css`. If `q` is an `Element`, it is returned unchanged.
@@ -167,9 +167,9 @@
   ([q] (css-finder *driver* q))
   ([driver q]
      (cond
-       (element-like? q) q
-       (map? q)     (core/find-elements driver q)
-       :else        (core/find-elements driver {:css q}))))
+      (element-like? q) q
+      (map? q)     (core/find-elements driver q)
+      :else        (core/find-elements driver {:css q}))))
 
 (set-finder! css-finder)
 
@@ -180,9 +180,9 @@
   ([q] (xpath-finder *driver* q))
   ([driver q]
      (cond
-       (element-like? q) q
-       (map? q)     (core/find-elements driver q)
-       :else        (core/find-elements driver {:xpath q}))))
+      (element-like? q) q
+      (map? q)     (core/find-elements driver q)
+      :else        (core/find-elements driver {:xpath q}))))
 
 ;; Be able to get actual element/elements when needed
 (defn element
@@ -555,7 +555,7 @@
    ;;
    ;; Full example
    ;;
-   (add-cookie {:name \"foo\", :value \"bar\", 
+   (add-cookie {:name \"foo\", :value \"bar\",
                 :domain \"example.com\", :path \"a-path\",
                 :expiry (java.util.Date.), :secure? false}) "
   ([cookie-spec] (add-cookie *driver* cookie-spec))
@@ -1261,7 +1261,7 @@
      (core/all-selected-options (element driver q))))
 
 (defn deselect-option
-  "Deselect the option element matching `attr-val` within the first select list found with query `q`. 
+  "Deselect the option element matching `attr-val` within the first select list found with query `q`.
 
    The `attr-val` can contain `:index`, `:value`, or `:text` keys to find the target option element. Index is the zero-based order of the option element in the list, value is the value of the HTML value attribute, and text is the visible text of the option element on the page.
 
@@ -1343,7 +1343,7 @@
   ([driver q] (core/multiple? (element driver q))))
 
 (defn select-option
-  "Select the option element matching `attr-val` within the first select list found with query `q`. 
+  "Select the option element matching `attr-val` within the first select list found with query `q`.
 
    The `attr-val` can contain `:index`, `:value`, or `:text` keys to find the target option element. Index is the zero-based order of the option element in the list, value is the value of the HTML value attribute, and text is the visible text of the option element on the page.
 
@@ -1444,9 +1444,9 @@
    (quick-fill {\"#first_name\" \"Rich\"}
                {\"a.foo\" click})"
   [& query-action-maps]
-  (flatten (map (fn [a-map]
-                  (let [[k v] (first a-map)] (quick-fill* k v)))
-                query-action-maps)))
+  (doall (flatten (map (fn [a-map]
+                         (let [[k v] (first a-map)] (quick-fill* k v)))
+                       query-action-maps))))
 
 (defn quick-fill-submit
   "A utility for filling out multiple fields in a form in one go. Always returns nil instead of the affected elements, since on submit all of the elements will be void.


### PR DESCRIPTION
The quick-fill function was returning a lazy sequence, which was not
realized until it was consumed. Hence if the sequence was never
consumed, the form would not get filled out. Adding a doall to the code
in quick-fill forces the realization of the sequence.
