### PR TITLE
Only configure clj-webdriver logging, rm appenders

### DIFF
--- a/resources/log4j.properties
+++ b/resources/log4j.properties
@@ -1,8 +1,1 @@
-log4j.rootLogger=WARN, R
-
-log4j.appender.R=org.apache.log4j.RollingFileAppender
-log4j.appender.R.File=test.log
-log4j.appender.R.MaxFileSize=1000KB
-log4j.appender.R.MaxBackupIndex=1
-log4j.appender.R.layout=org.apache.log4j.PatternLayout
-log4j.appender.R.layout.ConversionPattern=%d{ISO8601} %-5p [%c] - %m%n
+log4j.logger.clj_webdriver=WARN


### PR DESCRIPTION
Configuring the root logger means every application depending on
clj-webdriver will unexpectedly only log on the WARN level and print
to test.log.
