### PR TITLE
Fix taxi/elements to always return a list of elements, even when its argument is an element

### DIFF
--- a/src/clj_webdriver/taxi.clj
+++ b/src/clj_webdriver/taxi.clj
@@ -230,7 +230,7 @@
   ([q] (elements *driver* q))
   ([driver q]
      (if (element-like? q)
-       (list q)
+       (lazy-seq (list q))
        (*finder-fn* driver q))))
 
 ;; ## Driver functions ##


### PR DESCRIPTION
This allows quick-fill to be passed elements directly instead of selector strings.
