### PR TITLE
Let find-elements support :partial-text

### DIFF
--- a/src/clj_webdriver/taxi.clj
+++ b/src/clj_webdriver/taxi.clj
@@ -807,6 +807,7 @@
    (find-elements {:tag :radio, :class \"choice\"})
    (find-elements [{:tag :div, :id \"container\"},
                    {:tag :a, :class \"external\"}])
+   (find-elements {:tag :a, :partial-text \"foo\"})
 "
   ([attr-val] (find-elements *driver* attr-val))
   ([driver attr-val]

--- a/src/clj_webdriver/util.clj
+++ b/src/clj_webdriver/util.clj
@@ -25,6 +25,7 @@
   (apply str (for [[attr value] attr-val]
                (cond
                 (= :text attr) (str "[text()=\"" value "\"]")
+                (= :partial-text attr) (str "[contains(text(), \"" value "\")]")
                 (= :index attr) (str "[" (inc value) "]") ; in clj-webdriver,
                 :else (str "[@"                           ; all indices 0-based
                            (name attr)

--- a/test/clj_webdriver/test/taxi.clj
+++ b/test/clj_webdriver/test/taxi.clj
@@ -99,6 +99,9 @@
   (is (= (text "a[class*='exter'][href*='github']") "Moustache"))
   (is (= (count (elements "*[class*='-item']")) 5))
   (is (= (count (elements "a[class*='-item']")) 5))
+  (is (= (count (elements {:text "Moustache"})) 1))
+  (is (= (count (elements {:partial-text "Mousche"})) 0))
+  (is (= (count (elements {:partial-text "Moust"})) 1))
   (is (= (count (elements "a[class*='exter'][href*='github']")) 2)))
 
 (deftest test-querying-under-elements


### PR DESCRIPTION
This gives you a way to take the taxi to partial text. I expected a
place to add By.partiallLinkText(), but ended up with xpath. Not sure
if that's actually the proper thing to do.
