### PR TITLE
Fix direction in docstring

### DIFF
--- a/src/clj_webdriver/taxi.clj
+++ b/src/clj_webdriver/taxi.clj
@@ -315,7 +315,7 @@
    (forward)
 
    ;;
-   ;; Specify number of times to go back
+   ;; Specify number of times to go forward
    ;;
    (forward 2)"
   ([] (forward *driver* 1))


### PR DESCRIPTION
Just a minor fix while reading some of taxi. Thanks for the library! It's been helpful testing a pedestal app on travis
