### PR TITLE
allow platform-override in capabilities

### DIFF
--- a/src/clj_webdriver/remote/server.clj
+++ b/src/clj_webdriver/remote/server.clj
@@ -31,7 +31,10 @@
      (let [http-cmd-exec (HttpCommandExecutor. (as-url (address remote-server)))
            {:keys [browser]} browser-spec
            desired-caps (if (seq capabilities)
-                          (DesiredCapabilities. (util/java-keys capabilities))
+                          (let [result (DesiredCapabilities. (util/java-keys capabilities))]
+                            (when (:platform-override capabilities)
+                              (.. result (setCapability "platform" (:platform-override capabilities))))
+                            result)
                           (util/call-method DesiredCapabilities browser nil nil))
            remote-webdriver (RemoteWebDriverExt. http-cmd-exec desired-caps)]
        [remote-webdriver, desired-caps])))


### PR DESCRIPTION
This is a workaround for not being able to use any "platform" capability outside of the Platform enum  (http://selenium.googlecode.com/git/docs/api/java/org/openqa/selenium/Platform.html). 

This causes a problem, at least with Sauce Labs and Safari 6 (which requires platform = "MAC 10.8"). Using that with the previous code resulted in:
"No enum const class org.openqa.selenium.Platform.MAC 10.8  java.lang.Enum.valueOf"

Not sure this is the approach you want to take, but this was the only workaround I found. A more thorough workaround would be to allow more flexible construction of the DesiredCapabilities object by users of the lib, which I can attempt if you're open to that...
