### PR TITLE
Updated selenium versions to fix Firefox Issue

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,9 +14,9 @@
                                                 org.apache.httpcomponents/httpmime]]
                  [cheshire "2.1.0"]
                  [org.mortbay.jetty/jetty "6.1.25"]
-                 [org.seleniumhq.selenium/selenium-server "2.42.2"]
-                 [org.seleniumhq.selenium/selenium-java "2.42.2"]
-                 [org.seleniumhq.selenium/selenium-remote-driver "2.42.0"]
+                 [org.seleniumhq.selenium/selenium-server "2.44.0"]
+                 [org.seleniumhq.selenium/selenium-java "2.44.0"]
+                 [org.seleniumhq.selenium/selenium-remote-driver "2.44.0"]
                  [com.github.detro.ghostdriver/phantomjsdriver "1.0.4"
                   :exclusion [org.seleniumhq.selenium/selenium-java
                               org.seleniumhq.selenium/selenium-server


### PR DESCRIPTION
Trying the example in the docs will not open the url.
By updating the Selenium dependency this issue is fixed.