### PR TITLE
Updated dependencies for selenium 2.45.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,8 @@ This is a Clojure library for driving a web browser using Selenium-WebDriver as 
   <tbody>
     <tr>
       <td>Stable</td>
-      <td>January 20 2014</td>
-      <td><code>[clj-webdriver "0.6.1"]</code></td>
-    </tr>
-    <tr>
-      <td>Pre-Release</td>
-      <td>(Build locally)</td>
-      <td><code>[clj-webdriver "0.7.0-SNAPSHOT"]</code></td>
+      <td>April 17 2015</td>
+      <td><code>[net.info9/clj-webdriver "0.7.3"]</code></td>
     </tr>
   </tbody>
 </table>

--- a/project.clj
+++ b/project.clj
@@ -1,26 +1,23 @@
-(defproject net.info9/clj-webdriver "0.7.4"
+(defproject net.info9/clj-webdriver "0.7.5"
   :description "Clojure API for Selenium-WebDriver"
   :url "https://github.com/semperos/clj-webdriver"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :min-lein-version "2.0.0"
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/core.cache "0.6.4"]
                  [org.clojure/tools.logging "0.3.1"]
                  [org.clojure/tools.namespace "0.2.10"]
-                 [clj-http "1.1.2"]
-                 [cheshire "5.4.0"]
+                 [clj-http "2.0.0"]
+                 [cheshire "5.5.0"]
                  [org.mortbay.jetty/servlet-api-2.5 "6.1.14"]
-                 [org.eclipse.jetty/jetty-server "8.1.17.v20150415"]
-                 [org.eclipse.jetty/jetty-webapp "8.1.17.v20150415"]
-                 [org.eclipse.jetty/jetty-websocket "8.1.17.v20150415"]
-                 [com.google.code.gson/gson "2.2.4"]
-                 [org.seleniumhq.selenium/selenium-server "2.45.0"
-                  :exclusions [commons-codec com.google.code.gson/gson]]
-                 [org.seleniumhq.selenium/selenium-java "2.45.0"
-                  :exclusions [commons-codec com.google.code.gson/gson]]
-                 [org.seleniumhq.selenium/selenium-remote-driver "2.45.0"
-                  :exclusions [com.google.code.gson/gson]]
+                 [org.eclipse.jetty.websocket/websocket-client "9.2.10.v20150310"]
+                 [com.google.code.gson/gson "2.3.1"]
+                 [org.seleniumhq.selenium/selenium-server "2.47.1"
+                  :exclusions [org.eclipse.jetty.websocket/websocket-client]]
+                 [org.seleniumhq.selenium/selenium-java "2.47.1"
+                  :exclusions [org.eclipse.jetty.websocket/websocket-client]]
+                 [org.seleniumhq.selenium/selenium-remote-driver "2.47.1"]
                  [com.github.detro/phantomjsdriver "1.2.0" :exclusions
                   [org.seleniumhq.selenium/selenium-java
                    org.seleniumhq.selenium/selenium-server
@@ -28,18 +25,15 @@
   :profiles {:dev
              {:dependencies
               [[criterium "0.4.3"]
-               [codox "0.8.12"]
-               [clj-time "0.9.0"]
+               [codox "0.8.13"]
+               [clj-time "0.10.0"]
+               [org.clojure/clojurescript "1.7.28"]
                [marginalia "0.8.0"
                 :exclusions
-                [org.clojure/tools.namespace
-                 org.clojure/java.classpath]
-                ]
-               [ring "1.3.2"
-                :exclusions
-                [org.clojure/tools.namespace]]
+                [org.clojure/clojurescript]]
+               [ring "1.4.0"]
                [ring-http-basic-auth "0.0.2"]
-               [enlive "1.1.5"]
+               [enlive "1.1.6"]
                [net.cgrand/moustache "1.1.0" :exclusions
                 [org.clojure/clojure
                  ring/ring-core

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.info9/clj-webdriver "0.7.3"
+(defproject net.info9/clj-webdriver "0.7.4"
   :description "Clojure API for Selenium-WebDriver"
   :url "https://github.com/semperos/clj-webdriver"
   :license {:name "Eclipse Public License"
@@ -7,20 +7,20 @@
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/core.cache "0.6.4"]
                  [org.clojure/tools.logging "0.3.1"]
-                 ;; Exclude these, giving preference to Selenium-WebDriver's
-                 ;; dependence on them.
-                 [clj-http "1.1.0" :exclusions
-                  [org.apache.httpcomponents/httpclient
-                   org.apache.httpcomponents/httpcore
-                   org.apache.httpcomponents/httpmime]]
+                 [org.clojure/tools.namespace "0.2.10"]
+                 [clj-http "1.1.2"]
                  [cheshire "5.4.0"]
                  [org.mortbay.jetty/servlet-api-2.5 "6.1.14"]
-                 [org.eclipse.jetty/jetty-server "8.1.16.v20140903"]
-                 [org.eclipse.jetty/jetty-webapp "8.1.16.v20140903"]
-                 [org.eclipse.jetty/jetty-websocket "8.1.16.v20140903"]
-                 [org.seleniumhq.selenium/selenium-server "2.45.0"]
-                 [org.seleniumhq.selenium/selenium-java "2.45.0"]
-                 [org.seleniumhq.selenium/selenium-remote-driver "2.45.0"]
+                 [org.eclipse.jetty/jetty-server "8.1.17.v20150415"]
+                 [org.eclipse.jetty/jetty-webapp "8.1.17.v20150415"]
+                 [org.eclipse.jetty/jetty-websocket "8.1.17.v20150415"]
+                 [com.google.code.gson/gson "2.2.4"]
+                 [org.seleniumhq.selenium/selenium-server "2.45.0"
+                  :exclusions [commons-codec com.google.code.gson/gson]]
+                 [org.seleniumhq.selenium/selenium-java "2.45.0"
+                  :exclusions [commons-codec com.google.code.gson/gson]]
+                 [org.seleniumhq.selenium/selenium-remote-driver "2.45.0"
+                  :exclusions [com.google.code.gson/gson]]
                  [com.github.detro/phantomjsdriver "1.2.0" :exclusions
                   [org.seleniumhq.selenium/selenium-java
                    org.seleniumhq.selenium/selenium-server
@@ -28,12 +28,16 @@
   :profiles {:dev
              {:dependencies
               [[criterium "0.4.3"]
-               [codox "0.8.11"]
+               [codox "0.8.12"]
                [clj-time "0.9.0"]
-               [marginalia "0.8.0"]
-               [ring "1.3.2" :exclusions
+               [marginalia "0.8.0"
+                :exclusions
                 [org.clojure/tools.namespace
-                 org.clojure/java.classpath]]
+                 org.clojure/java.classpath]
+                ]
+               [ring "1.3.2"
+                :exclusions
+                [org.clojure/tools.namespace]]
                [ring-http-basic-auth "0.0.2"]
                [enlive "1.1.5"]
                [net.cgrand/moustache "1.1.0" :exclusions

--- a/project.clj
+++ b/project.clj
@@ -1,36 +1,45 @@
-(defproject clj-webdriver "0.6.1"
+(defproject net.info9/clj-webdriver "0.7.3"
   :description "Clojure API for Selenium-WebDriver"
   :url "https://github.com/semperos/clj-webdriver"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :min-lein-version "2.0.0"
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/core.cache "0.5.0"]
-                 [org.clojure/tools.logging "0.2.3"]
+  :dependencies [[org.clojure/clojure "1.6.0"]
+                 [org.clojure/core.cache "0.6.4"]
+                 [org.clojure/tools.logging "0.3.1"]
                  ;; Exclude these, giving preference to Selenium-WebDriver's
                  ;; dependence on them.
-                 [clj-http "0.3.0" :exclusions [org.apache.httpcomponents/httpclient
-                                                org.apache.httpcomponents/httpcore
-                                                org.apache.httpcomponents/httpmime]]
-                 [cheshire "2.1.0"]
-                 [org.mortbay.jetty/jetty "6.1.25"]
-                 [org.seleniumhq.selenium/selenium-server "2.43.0"]
-                 [org.seleniumhq.selenium/selenium-java "2.43.0"]
-                 [org.seleniumhq.selenium/selenium-remote-driver "2.43.0"]
-                 [com.github.detro/phantomjsdriver "1.2.0"
-                  :exclusion [org.seleniumhq.selenium/selenium-java
-                              org.seleniumhq.selenium/selenium-server
-                              org.seleniumhq.selenium/selenium-remote-driver]]]
+                 [clj-http "1.1.0" :exclusions
+                  [org.apache.httpcomponents/httpclient
+                   org.apache.httpcomponents/httpcore
+                   org.apache.httpcomponents/httpmime]]
+                 [cheshire "5.4.0"]
+                 [org.mortbay.jetty/servlet-api-2.5 "6.1.14"]
+                 [org.eclipse.jetty/jetty-server "8.1.16.v20140903"]
+                 [org.eclipse.jetty/jetty-webapp "8.1.16.v20140903"]
+                 [org.eclipse.jetty/jetty-websocket "8.1.16.v20140903"]
+                 [org.seleniumhq.selenium/selenium-server "2.45.0"]
+                 [org.seleniumhq.selenium/selenium-java "2.45.0"]
+                 [org.seleniumhq.selenium/selenium-remote-driver "2.45.0"]
+                 [com.github.detro/phantomjsdriver "1.2.0" :exclusions
+                  [org.seleniumhq.selenium/selenium-java
+                   org.seleniumhq.selenium/selenium-server
+                   org.seleniumhq.selenium/selenium-remote-driver]]]
   :profiles {:dev
              {:dependencies
-              [[criterium "0.2.0"]
-               [codox "0.3.3"]
-               [clj-time "0.4.4"]
-               [marginalia "0.3.2"]
-               [ring "1.0.2"]
+              [[criterium "0.4.3"]
+               [codox "0.8.11"]
+               [clj-time "0.9.0"]
+               [marginalia "0.8.0"]
+               [ring "1.3.2" :exclusions
+                [org.clojure/tools.namespace
+                 org.clojure/java.classpath]]
                [ring-http-basic-auth "0.0.2"]
-               [enlive "1.0.0"]
-               [net.cgrand/moustache "1.0.0"]]}}
+               [enlive "1.1.5"]
+               [net.cgrand/moustache "1.1.0" :exclusions
+                [org.clojure/clojure
+                 ring/ring-core
+                 org.mortbay.jetty/servlet-api-2.5]]]}}
   :aot [#"clj-webdriver\.ext\.*"]
-  :scm {:url "git@github.com:semperos/clj-webdriver.git"}
-  :pom-addition [:developers [:developer [:name "Daniel Gregoire"]]])
+  :scm {:url "git@github.com:tmarble/clj-webdriver.git"}
+  :pom-addition [:developers [:developer [:name "Tom Marble"]]])

--- a/src/clj_webdriver/remote/server.clj
+++ b/src/clj_webdriver/remote/server.clj
@@ -4,10 +4,10 @@
         [clj-webdriver.core :only [get-url]])
   (:require [clj-webdriver.util :as util])
   (:import clj_webdriver.ext.remote.RemoteWebDriverExt
-           [org.mortbay.jetty Connector Server]
-           org.mortbay.jetty.nio.SelectChannelConnector
-           org.mortbay.jetty.security.SslSocketConnector
-           org.mortbay.jetty.webapp.WebAppContext
+           [org.eclipse.jetty.server Connector Server]
+           org.eclipse.jetty.server.nio.SelectChannelConnector
+           org.eclipse.jetty.server.ssl.SslSocketConnector
+           org.eclipse.jetty.webapp.WebAppContext
            javax.servlet.Servlet
            org.openqa.selenium.remote.server.DriverServlet
            [org.openqa.selenium.remote


### PR DESCRIPTION
Please consider these changes to update the dependencies for clj-webdriver.

The new version is especially important for recent versions of Firefox.

--Tom
